### PR TITLE
Indicator is on the wrong side

### DIFF
--- a/Assets/HUD Indicator/Scripts/Components/OffScreen/IndicatorCanvasOffScreen.cs
+++ b/Assets/HUD Indicator/Scripts/Components/OffScreen/IndicatorCanvasOffScreen.cs
@@ -97,7 +97,10 @@ namespace HUDIndicator {
 
         private void UpdatePosition() {
             Rect rendererRect = renderer.GetRect();
-            Vector3 pos = renderer.GetRectTransform().InverseTransformPoint(renderer.camera.WorldToScreenPoint(indicator.gameObject.transform.position));
+            Vector3 screenPos = renderer.camera.WorldToScreenPoint(indicator.gameObject.transform.position);
+            if(screenPos.z < 0 ) screenPos.z = - screenPos.z;
+            Vector3 pos = renderer.GetRectTransform().InverseTransformPoint(screenPos);
+
 
             rendererRect.x += style.width / 2f;
             rendererRect.y += style.height / 2f;


### PR DESCRIPTION
I have noticed that when objects are far away (for instance 100m.), then the indicator is on the wrong side (at least with orthographic camera). The reason is that the screenPos.z becomes negative (?). I fixed it by making screenPos.z positive again, and then it works.